### PR TITLE
dropbox logging update

### DIFF
--- a/dropbox_langchain/dropbox_files.py
+++ b/dropbox_langchain/dropbox_files.py
@@ -519,7 +519,12 @@ class DropboxLoader(BaseLoader):
                 message=f"Error connecting to Dropbox: {str(error)}", level="ERROR"
             )
             raise
-
+        except Exception as error:
+            self.logMessage(
+                message=f"Unknown error connecting to Dropbox: {str(error)}",
+                level="ERROR",
+            )
+            raise
         # Initialize a new Dropbox object for team folders with the appropriate headers
         try:
             headers = {
@@ -536,6 +541,12 @@ class DropboxLoader(BaseLoader):
         except dropbox.exceptions.DropboxException as error:
             self.logMessage(
                 message=f"Error connecting to Dropbox team folder: {str(error)}",
+                level="ERROR",
+            )
+            raise
+        except Exception as error:
+            self.logMessage(
+                message=f"Unknown error connecting to Dropbox team folder: {str(error)}",
                 level="ERROR",
             )
             raise
@@ -560,8 +571,11 @@ class DropboxLoader(BaseLoader):
         except dropbox.exceptions.DropboxException as error:
             self.logMessage(message=f"Error loading files: {str(error)}", level="ERROR")
             raise
-
-        return []
+        except Exception as error:
+            self.logMessage(
+                message=f"Unknown error loading files: {str(error)}", level="ERROR"
+            )
+            raise
 
     def _filtered_statements_by_level(self, level) -> List:
         return [statement for statement in self.progress if statement.level == level]

--- a/dropbox_langchain/dropbox_files.py
+++ b/dropbox_langchain/dropbox_files.py
@@ -1,26 +1,26 @@
 """Loads Files from Dropbox."""
 
-import tempfile
 import json
-from typing import Any, List, Literal
-from pydantic import BaseModel
+import logging
 import pathlib
+import tempfile
+from typing import Any, List, Literal, Tuple
 
 from langchain.docstore.document import Document
 from langchain.document_loaders.base import BaseLoader
-
-from langchain_community.document_loaders import Docx2txtLoader
-from langchain_community.document_loaders import UnstructuredExcelLoader
-from langchain_community.document_loaders import UnstructuredPowerPointLoader
-from langchain_community.document_loaders import UnstructuredMarkdownLoader
-
+from langchain_community.document_loaders import (
+    Docx2txtLoader,
+    UnstructuredExcelLoader,
+    UnstructuredMarkdownLoader,
+    UnstructuredPowerPointLoader,
+)
+from pydantic import BaseModel
 from striprtf.striprtf import rtf_to_text
 
-import logging
 logger = logging.getLogger(__name__)
 
 ch = logging.StreamHandler()
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 
@@ -35,7 +35,7 @@ ALLOWED_EXTENSIONS = [
     "pdf",
     "rtf",
     "txt",
-    "paper"
+    "paper",
 ]
 
 
@@ -43,20 +43,30 @@ class LogStatement(BaseModel):
     """
     INFO can be user-facing statements, non-technical and perhaps very high-level
     """
+
     message: Any
-    level: Literal['INFO', 'DEBUG', 'WARNING']
+    level: Literal["INFO", "DEBUG", "WARNING", "ERROR"]
 
     def __json__(self):
         return {
-            'message': self.message,
-            'level': self.level,
+            "message": self.message,
+            "level": self.level,
         }
 
 
 class DropboxLoader(BaseLoader):
     """Loading logic for Dropbox files."""
 
-    def __init__(self, auth: dict, app_key: str = None, app_secret: str = None, folder_path: str = None, file_paths: List = None, file_path: str = None, is_team_folder: bool = False):
+    def __init__(
+        self,
+        auth: dict,
+        app_key: str | None = None,
+        app_secret: str | None = None,
+        folder_path: str | None = None,
+        file_paths: List[str] | None = None,
+        file_path: str | None = None,
+        is_team_folder: bool = False,
+    ):
         """Initialize with auth.
 
         Args:
@@ -96,6 +106,7 @@ class DropboxLoader(BaseLoader):
         self.invalid_files = []
 
         self.errors = []
+        self.warnings = []
         self.progress = []
 
     def _get_html_as_string(self, html) -> str:
@@ -117,33 +128,39 @@ class DropboxLoader(BaseLoader):
         filename = pathlib.Path(download_path).name
         file_contents = pathlib.Path(download_path).read_text()
 
-        return [Document(
-            page_content=file_contents.strip(),
-            metadata={ "source": source, "filename": filename, "kind": "file" }
-        )]
+        return [
+            Document(
+                page_content=file_contents.strip(),
+                metadata={"source": source, "filename": filename, "kind": "file"},
+            )
+        ]
 
     def _load_html_file(self, file_path, download_path, source) -> List[Document]:
         file_contents = pathlib.Path(download_path).read_text()
 
-        return [Document(
-            page_content=self._get_html_as_string(file_contents),
-            metadata={ "source": source, "kind": "file" }
-        )]
+        return [
+            Document(
+                page_content=self._get_html_as_string(file_contents),
+                metadata={"source": source, "kind": "file"},
+            )
+        ]
 
     def _load_rtf_file(self, file_path, download_path, source) -> List[Document]:
         file_contents = pathlib.Path(download_path).read_text()
 
-        return [Document(
-            page_content=rtf_to_text(file_contents).strip(),
-            metadata={ "source": source, "kind": "file" }
-        )]
+        return [
+            Document(
+                page_content=rtf_to_text(file_contents).strip(),
+                metadata={"source": source, "kind": "file"},
+            )
+        ]
 
     def _load_pdf_file(self, file_path, download_path, source) -> List[Document]:
         try:
             # Import PDF parser class
-            from PyPDF2 import PdfReader
-            from PyPDF2 import errors
             from binascii import Error as binasciiError
+
+            from PyPDF2 import PdfReader, errors
         except ImportError as exc:
             raise ImportError(
                 "Could not import PyPDF2 python package. "
@@ -156,19 +173,30 @@ class DropboxLoader(BaseLoader):
             pdf_reader = PdfReader(download_path)
 
             for i, page in enumerate(pdf_reader.pages):
-                docs.append(Document(
-                    page_content=page.extract_text(),
-                    metadata={"source": source, "kind": "file", "page": i+1}
-                ))
-        except errors.FileNotDecryptedError as err:
-            self._error_logger(error=f"PyPDF2.errors.FileNotDecryptedError: File has not been decrypted ({file_path})", action="read_pdf", entity_type="file")
-            self.logMessage(message={"message": {'filename': f"{file_path}", 'reason': 'not_indexed'}}, level='INFO')
+                docs.append(
+                    Document(
+                        page_content=page.extract_text(),
+                        metadata={"source": source, "kind": "file", "page": i + 1},
+                    )
+                )
+        except errors.FileNotDecryptedError:
+            self.logMessage(
+                message=(
+                    f"Error indexing ({file_path}):"
+                    "PyPDF2.errors.FileNotDecryptedError: File has not been decrypted "
+                ),
+                level="WARNING",
+            )
         except binasciiError as err:
-            self._error_logger(error=f"{str(err)} ({file_path})", action="read_pdf", entity_type="file")
-            self.logMessage(message={"message": {'filename': f"{file_path}", 'reason': 'not_indexed'}}, level='INFO')
+            self.logMessage(
+                message=f"{file_path} could not be decoded: {str(err)}",
+                level="WARNING",
+            )
         except Exception as err:
-            self._error_logger(error=f"{str(err)} ({file_path})", action="read_pdf", entity_type="file")
-            self.logMessage(message={"message": {'filename': f"{file_path}", 'reason': 'not_indexed'}}, level='INFO')
+            self.logMessage(
+                message=f"Error indexing ({file_path}): {str(err)}",
+                level="WARNING",
+            )
 
         return docs
 
@@ -197,8 +225,8 @@ class DropboxLoader(BaseLoader):
 
     def _normalize_docs(self, docs, source) -> List[Document]:
         for doc in docs:
-            doc.metadata['source'] = source
-            doc.metadata['kind'] = "file"
+            doc.metadata["source"] = source
+            doc.metadata["kind"] = "file"
 
         return docs
 
@@ -209,13 +237,13 @@ class DropboxLoader(BaseLoader):
 
         file_documents = []
 
-        file_extension = pathlib.Path(file_path).suffix.replace('.', '')
+        file_extension = pathlib.Path(file_path).suffix.replace(".", "")
         file_name = pathlib.Path(file_path).stem
 
         # Calculate source link (use https and preview link format - dropbox:// protocol isn't guaranteed to work)
         path_obj = pathlib.Path(file_path[1:])
         folders = path_obj.parts
-        folders = '/'.join(folders[:-1])
+        folders = "/".join(folders[:-1])
         source = f"https://www.dropbox.com/home/{folders}?preview={path_obj.name}"
 
         if file_extension in ALLOWED_EXTENSIONS:
@@ -225,65 +253,88 @@ class DropboxLoader(BaseLoader):
                     download_path = f"{temp_dir}/{file_name}"
 
                     try:
-                        dbx.files_export_to_file(download_path=download_path, path=file_path, export_format="markdown")
-                        file_documents = file_documents + self._load_md_file(file_path, download_path, source)
+                        dbx.files_export_to_file(
+                            download_path=download_path,
+                            path=file_path,
+                            export_format="markdown",
+                        )
+                        file_documents = file_documents + self._load_md_file(
+                            file_path, download_path, source
+                        )
                     except dropbox.exceptions.DropboxException as error:
-                        self.logMessage(message={"message": error, "file": file_path}, level='WARNING')
+                        self.logMessage(
+                            message=f"Error exporting ({file_path}): {str(error)}",
+                            level="WARNING",
+                        )
             else:
                 # Download file
                 with tempfile.TemporaryDirectory() as temp_dir:
                     download_path = f"{temp_dir}/{file_name}"
 
                     try:
-                        dbx.files_download_to_file(download_path=download_path, path=file_path)
+                        dbx.files_download_to_file(
+                            download_path=download_path, path=file_path
+                        )
 
                         if file_extension == "txt":
-                            file_documents = file_documents + self._load_text_file(file_path, download_path, source)
+                            file_documents = file_documents + self._load_text_file(
+                                file_path, download_path, source
+                            )
 
                         if file_extension in ["htm", "html"]:
-                            file_documents = file_documents + self._load_html_file(file_path, download_path, source)
+                            file_documents = file_documents + self._load_html_file(
+                                file_path, download_path, source
+                            )
 
                         elif file_extension == "pdf":
-                            file_documents = file_documents + self._load_pdf_file(file_path, download_path, source)
+                            file_documents = file_documents + self._load_pdf_file(
+                                file_path, download_path, source
+                            )
 
                         elif file_extension == "docx":
-                            file_documents = file_documents + self._load_docx_file(file_path, download_path, source)
+                            file_documents = file_documents + self._load_docx_file(
+                                file_path, download_path, source
+                            )
 
                         elif file_extension in ["xlsx", "xls"]:
-                            file_documents = file_documents + self._load_excel_file(file_path, download_path, source)
+                            file_documents = file_documents + self._load_excel_file(
+                                file_path, download_path, source
+                            )
 
                         elif file_extension == "pptx":
-                            file_documents = file_documents + self._load_pptx_file(file_path, download_path, source)
+                            file_documents = file_documents + self._load_pptx_file(
+                                file_path, download_path, source
+                            )
 
                         elif file_extension == "md":
-                            file_documents = file_documents + self._load_md_file(file_path, download_path, source)
+                            file_documents = file_documents + self._load_md_file(
+                                file_path, download_path, source
+                            )
 
                         elif file_extension == "rtf":
-                            file_documents = file_documents + self._load_rtf_file(file_path, download_path, source)
+                            file_documents = file_documents + self._load_rtf_file(
+                                file_path, download_path, source
+                            )
 
                     except dropbox.exceptions.DropboxException as error:
-                        self.logMessage(message={"message": error, "file": file_path}, level='WARNING')
+                        self.logMessage(
+                            message=f"Error downloading ({file_path}): {str(error)}",
+                            level="WARNING",
+                        )
 
         else:
-            self.invalid_files.append()
+            self.invalid_files.append(file_path)
 
         # Replace null character with space
         for doc in file_documents:
-            doc.page_content = doc.page_content.replace('\x00', ' ')
+            doc.page_content = doc.page_content.replace("\x00", " ")
 
         return file_documents
 
-    def _error_logger(self, error, action, entity_type) -> None:
-        if isinstance(error, str):
-            self.logMessage(message={"message": error, "action": action, "entity_type": entity_type}, level='WARNING')
-        elif isinstance(error.message, str):
-            message_json = json.loads(error.message)
-            self.logMessage(message={"message": message_json["errors"][0]["message"], "action": action, "entity_type": entity_type}, level='WARNING')
-        else:
-            self.logMessage(message={"message": error.message[0]["message"], "action": action, "entity_type": entity_type}, level='WARNING')
-
     def _load_files_from_folder_path(self, dbx, folder_path) -> List[Document]:
-        self.logMessage(message=f"Load files from folder path ({folder_path})", level="DEBUG")
+        self.logMessage(
+            message=f"Load files from folder path ({folder_path})", level="DEBUG"
+        )
 
         import dropbox
 
@@ -306,7 +357,7 @@ class DropboxLoader(BaseLoader):
 
                 for file in files.entries:
                     if isinstance(file, dropbox.files.FileMetadata):
-                        file_extension = pathlib.Path(file.name).suffix.replace('.', '')
+                        file_extension = pathlib.Path(file.name).suffix.replace(".", "")
 
                         if file_extension in ALLOWED_EXTENSIONS:
                             file_paths.append(file.path_display)
@@ -317,78 +368,92 @@ class DropboxLoader(BaseLoader):
                 if files.has_more is False:
                     found_all_records = True
 
-            file_documents = self._load_files_from_paths(
-                dbx=dbx,
-                file_paths=file_paths
-            )
+            file_documents = self._load_files_from_paths(dbx=dbx, file_paths=file_paths)
         except dropbox.exceptions.DropboxException as error:
-            self.errors.append({"message": error, "folder": folder_path})
+            self.logMessage(
+                message=f"Error listing folder ({folder_path}): {str(error)}",
+                level="WARNING",
+            )
 
         return file_documents
 
     def _load_files_from_paths(self, dbx, file_paths) -> List[Document]:
-        self.logMessage(message=f"Load files from file paths (count: {len(file_paths)})", level="DEBUG")
+        self.logMessage(
+            message=f"Load files from file paths (count: {len(file_paths)})",
+            level="DEBUG",
+        )
 
         file_documents = []
 
         for file_path in file_paths:
             file_documents = file_documents + self._load_file(
-                dbx=dbx,
-                file_path=file_path
+                dbx=dbx, file_path=file_path
             )
 
         return file_documents
 
     def logMessage(self, message, level):
-        if level == 'INFO':
+        if level == "INFO":
             logger.info(message)
-        if level == 'DEBUG':
+        if level == "DEBUG":
             logger.debug(message)
-        if level == 'WARNING':
+        if level == "WARNING":
             logger.warning(message)
+            self.warnings.append(LogStatement(message=message, level=level))
+        if level == "ERROR":
+            logger.error(message)
+            self.errors.append(LogStatement(message=message, level=level))
 
-            self.errors.append(LogStatement(
-                message=message,
-                level=level
-            ))
-
-        self.progress.append(LogStatement(
-            message=message,
-            level=level
-        ))
+        self.progress.append(LogStatement(message=message, level=level))
 
     def list_folders(self, dbx, root_namespace_id=None):
         import dropbox
+
         entries_info = []
         try:
             files = None
             found_all_records = False
-            dbx = dbx.with_path_root(dropbox.common.PathRoot.root(root_namespace_id)) if root_namespace_id else dbx
+            dbx = (
+                dbx.with_path_root(dropbox.common.PathRoot.root(root_namespace_id))
+                if root_namespace_id
+                else dbx
+            )
 
             while not found_all_records:
                 if files is None:
-                    files = dbx.files_list_folder("", recursive=False, include_deleted=False)
+                    files = dbx.files_list_folder(
+                        "", recursive=False, include_deleted=False
+                    )
                 else:
                     files = dbx.files_list_folder_continue(files.cursor)
 
                 for entry in files.entries:
                     if isinstance(entry, dropbox.files.FolderMetadata):
-                        entries_info.append({
-                            "name": entry.name,
-                            "path_display": entry.path_display,
-                            "parent_shared_folder_id": entry.parent_shared_folder_id if hasattr(entry, 'parent_shared_folder_id') else None
-                        })
+                        entries_info.append(
+                            {
+                                "name": entry.name,
+                                "path_display": entry.path_display,
+                                "parent_shared_folder_id": (
+                                    entry.parent_shared_folder_id
+                                    if hasattr(entry, "parent_shared_folder_id")
+                                    else None
+                                ),
+                            }
+                        )
                 if not files.has_more:
                     found_all_records = True
 
         except dropbox.exceptions.DropboxException as error:
-            self.errors.append({"message": error})
+            self.logMessage(
+                message=f"Error listing folders: {str(error)}", level="WARNING"
+            )
         return entries_info
 
     def get_folders(self):
         import dropbox
+
         try:
-            with dropbox.Dropbox(oauth2_access_token=self.auth['access_token']) as dbx:
+            with dropbox.Dropbox(oauth2_access_token=self.auth["access_token"]) as dbx:
                 account_info = dbx.users_get_current_account()
                 root_namespace_id = account_info.root_info.root_namespace_id
 
@@ -398,7 +463,9 @@ class DropboxLoader(BaseLoader):
 
                 return all_entries_info
         except dropbox.exceptions.DropboxException as error:
-            self.errors.append({"message": error})
+            self.logMessage(
+                message=f"Error getting folders: {str(error)}", level="WARNING"
+            )
             return []
 
     def load(self) -> List[Document]:
@@ -413,45 +480,63 @@ class DropboxLoader(BaseLoader):
             ) from exp
 
         # earlier versions of this library used `access`, but the dropbox api returns `access_token`
-        if 'access' in self.auth:
-            args = {"oauth2_access_token": self.auth['access']}
+        args = dict()
+
+        if "access" in self.auth:
+            args = {"oauth2_access_token": self.auth["access"]}
 
         # preferred
-        if 'access_token' in self.auth:
-            args = {"oauth2_access_token": self.auth['access_token']}
+        if "access_token" in self.auth:
+            args = {"oauth2_access_token": self.auth["access_token"]}
 
         # If an app_key + secret is specified, pass in refresh token, app_key, app_secret
         if self.app_key is not None and self.app_secret is not None:
             # earlier versions of this library used `refresh`, but the dropbox api returns `refresh_token`
-            if 'refresh' in self.auth:
-                args['oauth2_refresh_token'] = self.auth['refresh']
+            if "refresh" in self.auth:
+                args["oauth2_refresh_token"] = self.auth["refresh"]
 
             # preferred
-            if 'refresh_token' in self.auth:
-                args['oauth2_refresh_token'] = self.auth['refresh_token']
-            args['app_key'] = self.app_key
-            args['app_secret'] = self.app_secret
+            if "refresh_token" in self.auth:
+                args["oauth2_refresh_token"] = self.auth["refresh_token"]
+
+            args["app_key"] = self.app_key
+            args["app_secret"] = self.app_secret
 
         # Initialize a new Dropbox object
         try:
             dbx_personal = dropbox.Dropbox(**args)
             account_info = dbx_personal.users_get_current_account()
+        except dropbox.exceptions.AuthError:
+            self.logMessage(
+                message="Invalid Dropbox credentials. Please allow access your Dropbox account.",
+                level="ERROR",
+            )
+            raise
         except dropbox.exceptions.DropboxException as error:
-            self.errors.append({"message": error})
-            return []
+            self.logMessage(
+                message=f"Error connecting to Dropbox: {str(error)}", level="ERROR"
+            )
+            raise
 
         # Initialize a new Dropbox object for team folders with the appropriate headers
         try:
             headers = {
-                "Dropbox-API-Path-Root": json.dumps({
-                    ".tag": "namespace_id",
-                    "namespace_id": account_info.root_info.root_namespace_id
-                })
+                "Dropbox-API-Path-Root": json.dumps(
+                    {
+                        ".tag": "namespace_id",
+                        "namespace_id": account_info.root_info.root_namespace_id,
+                    }
+                )
             }
-            dbx_team = dropbox.Dropbox(oauth2_access_token=self.auth['access_token'], headers=headers)
+            dbx_team = dropbox.Dropbox(
+                oauth2_access_token=self.auth["access_token"], headers=headers
+            )
         except dropbox.exceptions.DropboxException as error:
-            self.errors.append({"message": error})
-            return []
+            self.logMessage(
+                message=f"Error connecting to Dropbox team folder: {str(error)}",
+                level="ERROR",
+            )
+            raise
 
         # Use the appropriate Dropbox client based on the folder type
         dbx = dbx_team if self.is_team_folder else dbx_personal
@@ -469,19 +554,17 @@ class DropboxLoader(BaseLoader):
                     file_paths=self.file_paths,
                 )
 
-            return self._load_file(
-                dbx=dbx,
-                file_path=self.file_path
-            )
+            return self._load_file(dbx=dbx, file_path=self.file_path)
         except dropbox.exceptions.DropboxException as error:
-            self.errors.append({"message": error})
+            self.logMessage(message=f"Error loading files: {str(error)}", level="ERROR")
+            raise
 
         return []
 
     def _filtered_statements_by_level(self, level) -> List:
         return [statement for statement in self.progress if statement.level == level]
 
-    def get_details(self, level='INFO') -> List:
-        if level == 'INFO':
-            return self._filtered_statements_by_level(level), self.errors
-        return self.progress, self.errors
+    def get_details(self, level="INFO") -> Tuple:
+        if level == "INFO":
+            return self._filtered_statements_by_level(level), self.warnings, self.errors
+        return self.progress, self.warnings, self.errors

--- a/dropbox_langchain/dropbox_files.py
+++ b/dropbox_langchain/dropbox_files.py
@@ -395,14 +395,16 @@ class DropboxLoader(BaseLoader):
     def logMessage(self, message, level):
         if level == "INFO":
             logger.info(message)
-        if level == "DEBUG":
+        elif level == "DEBUG":
             logger.debug(message)
-        if level == "WARNING":
+        elif level == "WARNING":
             logger.warning(message)
             self.warnings.append(LogStatement(message=message, level=level))
-        if level == "ERROR":
+        elif level == "ERROR":
             logger.error(message)
             self.errors.append(LogStatement(message=message, level=level))
+        else:
+            logger.debug(f"Unknown log level: {level}, message: {message}")
 
         self.progress.append(LogStatement(message=message, level=level))
 

--- a/dropbox_langchain/dropbox_files.py
+++ b/dropbox_langchain/dropbox_files.py
@@ -568,9 +568,6 @@ class DropboxLoader(BaseLoader):
                 )
 
             return self._load_file(dbx=dbx, file_path=self.file_path)
-        except dropbox.exceptions.DropboxException as error:
-            self.logMessage(message=f"Error loading files: {str(error)}", level="ERROR")
-            raise
         except Exception as error:
             self.logMessage(
                 message=f"Unknown error loading files: {str(error)}", level="ERROR"

--- a/dropbox_langchain/dropbox_files.py
+++ b/dropbox_langchain/dropbox_files.py
@@ -23,7 +23,7 @@ ch = logging.StreamHandler()
 formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 ch.setFormatter(formatter)
 logger.addHandler(ch)
-
+LogLevel = Literal["INFO", "DEBUG", "WARNING", "ERROR"]
 ALLOWED_EXTENSIONS = [
     "md",
     "htm",
@@ -392,7 +392,7 @@ class DropboxLoader(BaseLoader):
 
         return file_documents
 
-    def logMessage(self, message, level):
+    def logMessage(self, message, level: LogLevel = "INFO"):
         if level == "INFO":
             logger.info(message)
         elif level == "DEBUG":
@@ -577,10 +577,10 @@ class DropboxLoader(BaseLoader):
             )
             raise
 
-    def _filtered_statements_by_level(self, level) -> List:
+    def _filtered_statements_by_level(self, level: LogLevel) -> List:
         return [statement for statement in self.progress if statement.level == level]
 
-    def get_details(self, level="INFO") -> Tuple:
+    def get_details(self, level: LogLevel = "INFO") -> Tuple:
         if level == "INFO":
             return self._filtered_statements_by_level(level), self.warnings, self.errors
         return self.progress, self.warnings, self.errors

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='dropbox_langchain',
-    version='0.11.0',
+    version='0.12.0',
     description='A Dropbox langchain integration',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
## What this PR does:

Makes logging more consistent and robust in DropboxLoader, and bumps the package version to reflect improvements.

Changes
- Converted multiple if checks into if/elif structure to avoid redundant evaluations.
- Added explicit else branch to handle unknown log levels with a debug log.
- Ensured warnings and errors are consistently appended to internal tracking lists.
- Bumped version from 0.11.0 to 0.12.0.

## Steps to test:
- Use the [feature/indexing-logging-updates](https://github.com/umich-its-ai/umichgpt/tree/feature/indexing-logging-updates) for testing. Do a `docker compose build --no-cache` to ensure that this branch is loaded
- Test dropbox indexing. I would recommend indexing a larger folder to validate logging behavior 
- Open `/admin/t2/projecttaskresult/`. Ensure that the logs look clean and correctly log each level.
- Revoke Maizey's access from [Dropbox](https://www.dropbox.com/account/connected_apps). Reindex using the reindex button on the project link card. It should result in a failed index
- Refresh `/admin/t2/projecttaskresult/`. Ensure that the log is easy to follow with both an error and a more detailed exception trace.


## Screenshots:
Successful index:

<img width="1178" height="253" alt="image" src="https://github.com/user-attachments/assets/ca0f66f8-b9e3-4e2c-89ad-a030c8ae97bf" />

Failed Index:

<img width="1187" height="618" alt="image" src="https://github.com/user-attachments/assets/a3e9ec66-9f52-4cae-a362-8517b345d2fb" />

