### PR TITLE
GPT-2002 Upgrade Expected LangChain Version to 1.2.x

### DIFF
--- a/dropbox_langchain/dropbox_files.py
+++ b/dropbox_langchain/dropbox_files.py
@@ -6,8 +6,8 @@ import pathlib
 import tempfile
 from typing import Any, List, Literal, Tuple
 
-from langchain.docstore.document import Document
-from langchain.document_loaders.base import BaseLoader
+from langchain_classic.docstore.document import Document
+from langchain_classic.document_loaders.base import BaseLoader
 from langchain_community.document_loaders import (
     Docx2txtLoader,
     UnstructuredExcelLoader,
@@ -110,7 +110,6 @@ class DropboxLoader(BaseLoader):
         self.progress = []
 
     def _get_html_as_string(self, html) -> str:
-
         try:
             # Import the html parser class
             from bs4 import BeautifulSoup

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-langchain
-langchain-community
+langchain>=1.2.0,<2.0.0
+langchain-community>=0.4.1,<1.0.0
 unstructured
 beautifulsoup4
 lxml

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def load_requirements(path: str) -> list[str]:
 
 setup(
     name="dropbox_langchain",
-    version="0.12.0",
+    version="0.13.0",
     description="A Dropbox langchain integration",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,30 +1,29 @@
 from setuptools import setup, find_packages
 
+
+def load_requirements(path: str) -> list[str]:
+    with open(path, encoding="utf-8") as req_file:
+        return [
+            line.strip()
+            for line in req_file
+            if line.strip() and not line.startswith("#")
+        ]
+
+
 setup(
-    name='dropbox_langchain',
-    version='0.12.0',
-    description='A Dropbox langchain integration',
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    author='University of Michigan',
-    author_email='noreply@umich.edu',
-    url='https://github.com/umich-its-ai/langchain-doc-dropbox',
+    name="dropbox_langchain",
+    version="0.12.0",
+    description="A Dropbox langchain integration",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    author="University of Michigan",
+    author_email="noreply@umich.edu",
+    url="https://github.com/umich-its-ai/langchain-doc-dropbox",
     packages=find_packages(),
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'License :: OSI Approved :: GNU General Public License (GPL)'
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: GNU General Public License (GPL)",
     ],
-    install_requires=[
-        'langchain',
-        'langchain-community',
-        'unstructured',
-        'dropbox',
-        'beautifulsoup4',
-        'lxml',
-        'PyPDF2[crypto]',
-        'pydantic',
-        'docx2txt',
-        'striprtf'
-    ],
-    python_requires='>=3.8.1',
+    install_requires=load_requirements("requirements.txt"),
+    python_requires=">=3.8.1",
 )


### PR DESCRIPTION
This PR upgrades the expected version of LangChain (and it's usages) to 1.2.x. Most notably, this meant using `langchain_classic` to import certain utilities.

I also ended up replacing the list of dependencies in `setup.py` to use `requirements.txt` so that we don't have a duplicate list.

After this is merged, a release will be created and we'll get it [updated in the umichgpt repo](https://github.com/umich-its-ai/umichgpt/pull/1964).

---

To test, you can try to run this repo using the instructions in the README, but even then it's probably enough to see that the imports don't fail at runtime (even if it complains that you're missing environment variables). You can also test using the draft branch over in umichgpt world; it should be set up to point to this branch for the dependency.